### PR TITLE
Update to php 7.4 and tie Magento version to 2.3.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,6 +115,7 @@ magento_admin_lastname: ""
 magento_language: "en_US"
 magento_currency: "USD"
 magento_base_url: ""
+magento_version: "2.3.7"
 
 
 ###

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,12 +16,12 @@
 - name: Ensure nginx is started and enabled to start at boot.
   service: name=nginx state=started enabled=yes
 
-# Setup/install php-fpm 7.0 tasks.
+# Setup/install php-fpm 7.4 tasks.
 - include: setup-php7.yml
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure php-fpm is started and enabled to start at boot.
-  service: name=php70-php-fpm state=started enabled=yes
+  service: name=php74-php-fpm state=started enabled=yes
 
 #Setup/install Composer
 - include: setup-composer.yml

--- a/tasks/setup-magento2-composer.yml
+++ b/tasks/setup-magento2-composer.yml
@@ -6,7 +6,7 @@
   file: path="{{ magento_root_dir }}" state=directory
 
 - name: Create magento project
-  shell: composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition .
+  shell: composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition={{ magento_version }} .
   args:
     chdir: "{{ magento_root_dir }}"
     creates: "{{ magento_root_dir }}/composer.json"

--- a/tasks/setup-php7.yml
+++ b/tasks/setup-php7.yml
@@ -5,20 +5,22 @@
 - name: Add repository 'remi-repo'
   command: rpm -ih http://rpms.famillecollet.com/enterprise/remi-release-7.rpm creates=/etc/yum.repos.d/remi.repo
 
-- name: install php70
+- name: install php74
   yum: name={{ item }} enablerepo=epel,remi,remi-php70 state=installed
   with_items:
-    - php70
-    - php70-php-mcrypt
-    - php70-php-mbstring
-    - php70-php-fpm
-    - php70-php-gd
-    - php70-php-xml
-    - php70-php-pdo
-    - php70-php-zip
-    - php70-php-intl
-    - php70-php-soap
-    - php70-php-pdo_mysql  
+    - php74
+    - php74-php-mcrypt
+    - php74-php-mbstring
+    - php74-php-fpm
+    - php74-php-gd
+    - php74-php-xml
+    - php74-php-pdo
+    - php74-php-zip
+    - php74-php-intl
+    - php74-php-soap
+    - php74-php-pdo_mysql 
+    - php74-php-sodium
+    - php74-php-bcmath
 
 - name : link env file
   command: ln -s /opt/remi/php70/enable /etc/profile.d/php70.sh creates=/etc/profile.d/php70.sh


### PR DESCRIPTION
With this PR I upgrade php 7.0 to php 7.4 (see [here](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements.html) ) to be able to install latest 2.3.7 version (2.4 version requires ElasticSearch)

Thanks for sharing your code :)  